### PR TITLE
Add schemastore schema option

### DIFF
--- a/hatch_build.py
+++ b/hatch_build.py
@@ -1,12 +1,30 @@
-from functools import partial
-from io import StringIO
-from logging import shutdown
 from pathlib import Path
-import os
-import shlex
-from subprocess import call, check_call
+from subprocess import check_call
 import sys
+
+import requests
 from hatchling.builders.hooks.plugin.interface import BuildHookInterface
+
+
+ROOT = Path(".").resolve()
+SRC = ROOT / "src"
+SCHEMA = SRC / "schema"
+SCHEMASTORE = SRC / "schemastore"
+MODELS = SRC / "my_schema_project" / "models"
+
+SCHEMASTORE_URL = (
+    "https://raw.githubusercontent.com/SchemaStore/schemastore/master/src/schemas/json/"
+)
+
+# Add `datamodel_code_generator` flags here
+MY_SCHEMAS = {"my_schema_model.json": {"flags": []}}
+
+# Add `datamodel_code_generator` flags here
+SCHEMASTORE_SCHEMAS = {
+    "github-workflow.json": {"flags": ["--allow-population-by-field-name"]}
+}
+
+ALL_SCHEMA = {**MY_SCHEMAS, **SCHEMASTORE_SCHEMAS}
 
 
 class SchemaCodeGen(BuildHookInterface):
@@ -14,26 +32,33 @@ class SchemaCodeGen(BuildHookInterface):
 
     def initialize(self, version, build_data):
         L = get_logger()
-        WIN = os.name == "nt"
+        L.info("fetch schemastore schema")
+
+        for schema in SCHEMASTORE_SCHEMAS.keys():
+            SCHEMASTORE.mkdir(exist_ok=True)
+            target = SCHEMASTORE / schema
+            with target.open("w+") as file:
+                r = requests.get(SCHEMASTORE_URL + schema)
+                file.write(r.text)
+
         L.info("converting json schema to python")
-        ROOT = Path(self.root)
-        SRC = ROOT / "src"
-        SCHEMA = (SRC / "schema")
-        MODELS = (SRC / "my_schema_project" / "models")
         MODELS.mkdir(exist_ok=True)
 
-        for path in SCHEMA.glob("*.json"):
-            target =(MODELS / path.with_suffix(".py").name)
+        for path in [*SCHEMA.glob("*.json"), *SCHEMASTORE.glob("*.json")]:
+            target = MODELS / path.with_suffix(".py").name
+            flags = ALL_SCHEMA.get(path.name).get("flags")
             with target.open("w") as file:
-                check_call([
-                    sys.executable,
-                    "-m", 
-                    "datamodel_code_generator",
-                    "--input", path
-                    ], stdout=file)
-            build_data["artifacts"].append(
-                "/" + str(target)
-            )
+                gen_models(path, file, flags)
+            build_data["artifacts"].append("/" + str(target))
+
+    def finalize(self, version, build_data, artifact_path):
+        L = get_logger()
+        L.info("delete schemastore schema")
+
+        for f in SCHEMASTORE.glob("*.json"):
+            f.unlink()
+
+        SCHEMASTORE.rmdir()
 
 
 def get_logger():
@@ -43,3 +68,17 @@ def get_logger():
     logger.setLevel(logging.INFO)
     logging.basicConfig(level=logging.INFO)
     return logger
+
+
+def gen_models(input: str, output: str, flags: list = []):
+    check_call(
+        [
+            sys.executable,
+            "-m",
+            "datamodel_code_generator",
+            "--input",
+            input,
+            *flags,
+        ],
+        stdout=output,
+    )


### PR DESCRIPTION
Earlier this year you helped me think deeply about an important but undervalued concept: schema. It feels like this has now come full circle. Using this package, I can now programmatically write Github-Action workflows using Python :)

In this PR, we download the raw schemastore schemas, generator their pydantic models (with any necessary flags), and then delete the raw schema.

I had fun working on this. I can't claim its the cleanest approach but I'm happy to get feedback. 

Thanks again for everything @tonyfast!